### PR TITLE
fix the duplicate bug of undirected grid(#1)

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -289,81 +289,70 @@ function doPddlInsertGrid(directed, xval, yval, lpre, lpos, monolithicGridType, 
     for (var i = 1; i <= xval; i++) {
         for (var j = 1; j <= yval; j++) {
             var l1, l2, l3, l4;
-            // Go left
-            if (i > 1) {
-                if (monolithicGridType) {
-                    l1 = lpre + i + '_' + j + lpos;
-                    l2 = lpre + (i-1) + '_' + j + lpos;
-                    pddl += '\n(' + conPred + ' ' + l1 + ' ' + l2 + ')';
-                    if (!directed)
-                        pddl += '\n(' + conPred + ' ' + l2 + ' ' + l1 + ')';
-                } else {
-                    l1 = lpre + i + lpos;
-                    l2 = lpre + j + lpos;
-                    l3 = lpre + (i-1) + lpos;
-                    l4 = lpre + j + lpos;
-                    pddl += '\n(' + conPred + ' ' + l1 + ' ' + l2 + ' ' + l3 + ' ' + l4 + ')';
-                    if (!directed)
-                        pddl += '\n(' + conPred + ' ' + l3 + ' ' + l4 + ' ' + l1 + ' ' + l2 + ')';
-                }
-            }
-
+            // All the points are drawn to the right except for the right-most column
             // Go right
             if (i < xval) {
                 if (monolithicGridType) {
                     l1 = lpre + i + '_' + j + lpos;
                     l2 = lpre + (i+1) + '_' + j + lpos;
                     pddl += '\n(' + conPred + ' ' + l1 + ' ' + l2 + ')';
-                    if (!directed)
-                        pddl += '\n(' + conPred + ' ' + l2 + ' ' + l1 + ')';
                 } else {
                     l1 = lpre + i + lpos;
                     l2 = lpre + j + lpos;
                     l3 = lpre + (i+1) + lpos;
                     l4 = lpre + j + lpos;
                     pddl += '\n(' + conPred + ' ' + l1 + ' ' + l2 + ' ' + l3 + ' ' + l4 + ')';
-                    if (!directed)
-                        pddl += '\n(' + conPred + ' ' + l3 + ' ' + l4 + ' ' + l1 + ' ' + l2 + ')';
                 }
             }
-
+            // All the points are drawn to the up except for the front-most row
             // Go up
             if (j < yval) {
                 if (monolithicGridType) {
                     l1 = lpre + i + '_' + j + lpos;
                     l2 = lpre + i + '_' + (j+1) + lpos;
                     pddl += '\n(' + conPred + ' ' + l1 + ' ' + l2 + ')';
-                    if (!directed)
-                        pddl += '\n(' + conPred + ' ' + l2 + ' ' + l1 + ')';
                 } else {
                     l1 = lpre + i + lpos;
                     l2 = lpre + j + lpos;
                     l3 = lpre + i + lpos;
                     l4 = lpre + (j+1) + lpos;
                     pddl += '\n(' + conPred + ' ' + l1 + ' ' + l2 + ' ' + l3 + ' ' + l4 + ')';
-                    if (!directed)
-                        pddl += '\n(' + conPred + ' ' + l3 + ' ' + l4 + ' ' + l1 + ' ' + l2 + ')';
                 }
             }
 
-            // Go down
-            if (j > 1) {
-                if (monolithicGridType) {
-                    l1 = lpre + i + '_' + j + lpos;
-                    l2 = lpre + i + '_' + (j-1) + lpos;
-                    pddl += '\n(' + conPred + ' ' + l1 + ' ' + l2 + ')';
-                    if (!directed)
-                        pddl += '\n(' + conPred + ' ' + l2 + ' ' + l1 + ')';
-                } else {
-                    l1 = lpre + i + lpos;
-                    l2 = lpre + j + lpos;
-                    l3 = lpre + i + lpos;
-                    l4 = lpre + (j-1) + lpos;
-                    pddl += '\n(' + conPred + ' ' + l1 + ' ' + l2 + ' ' + l3 + ' ' + l4 + ')';
-                    if (!directed)
-                        pddl += '\n(' + conPred + ' ' + l3 + ' ' + l4 + ' ' + l1 + ' ' + l2 + ')';
+            // When it is a directed graph, reverse and rebuild a line between 2 points
+            if (directed) {
+                // Go left
+                if (i > 1) {
+                    if (monolithicGridType) {
+                        l1 = lpre + i + '_' + j + lpos;
+                        l2 = lpre + (i-1) + '_' + j + lpos;
+                        pddl += '\n(' + conPred + ' ' + l1 + ' ' + l2 + ')';
+                    } else {
+                        l1 = lpre + i + lpos;
+                        l2 = lpre + j + lpos;
+                        l3 = lpre + (i-1) + lpos;
+                        l4 = lpre + j + lpos;
+                        pddl += '\n(' + conPred + ' ' + l1 + ' ' + l2 + ' ' + l3 + ' ' + l4 + ')';
+                    }
+                }
+
+                // Go down
+                if (j > 1) {
+                    if (monolithicGridType) {
+                        l1 = lpre + i + '_' + j + lpos;
+                        l2 = lpre + i + '_' + (j-1) + lpos;
+                        pddl += '\n(' + conPred + ' ' + l1 + ' ' + l2 + ')';
+                    } else {
+                        l1 = lpre + i + lpos;
+                        l2 = lpre + j + lpos;
+                        l3 = lpre + i + lpos;
+                        l4 = lpre + (j-1) + lpos;
+                        pddl += '\n(' + conPred + ' ' + l1 + ' ' + l2 + ' ' + l3 + ' ' + l4 + ')';
+                    }
                 }
             }
+
         }
     }
 


### PR DESCRIPTION
![12](https://user-images.githubusercontent.com/20870937/92634333-b75e8600-f306-11ea-8ead-0c2fe268479b.png)

![22](https://user-images.githubusercontent.com/20870937/92634266-9dbd3e80-f306-11ea-8174-b519fe28c1b0.png)

The above pics show the current bug.
***********************************************************************************************
To calculate the number of edges in an undirected graph, we should count the lines between points.

So, for each point except that in the right-most, draw right, 
for each point except that in the front-most, draw up.

If we want a directed graph, we double the edges by drawing left and down.
